### PR TITLE
Add OpenAPI specs

### DIFF
--- a/spec/integration/analytics_spec.rb
+++ b/spec/integration/analytics_spec.rb
@@ -1,0 +1,86 @@
+require 'swagger_helper'
+
+RSpec.describe 'Patients analytics API', type: :request do
+  path '/api/v1/patients/{patient_id}/adherence' do
+    get 'Patient adherence statistics' do
+      tags 'Patients'
+      produces 'application/json'
+
+      parameter name: :patient_id, in: :path, type: :string
+      parameter name: :drug_name, in: :query, type: :string, required: true
+      parameter name: :Authorization, in: :header, type: :string, required: true, description: 'Bearer API key'
+
+      response '200', 'statistics retrieved' do
+        schema type: :object,
+               properties: {
+                 drug_name: { type: :string },
+                 interval_in_days: { type: :integer },
+                 starts_on: { type: :string, format: 'date' },
+                 expected_injections: { type: :integer },
+                 actual_injections: { type: :integer },
+                 on_time_injections: { type: :integer },
+                 adherence_score: { type: :number }
+               },
+               required: ['drug_name', 'interval_in_days', 'starts_on', 'expected_injections', 'actual_injections', 'on_time_injections', 'adherence_score']
+
+        let(:patient) { Patient.create(name: 'Alice') }
+        let(:patient_id) { patient.id }
+        let(:Authorization) { "Bearer #{patient.api_key}" }
+        let(:drug_name) { patient.schedules.first.drug_name }
+
+        run_test!
+      end
+
+      response '404', 'schedule not found' do
+        let(:patient) { Patient.create(name: 'Alice') }
+        let(:patient_id) { patient.id }
+        let(:Authorization) { "Bearer #{patient.api_key}" }
+        let(:drug_name) { 'Unknown' }
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/patients/{patient_id}/injections_schedule' do
+    get 'Patient injections schedule' do
+      tags 'Patients'
+      produces 'application/json'
+
+      parameter name: :patient_id, in: :path, type: :string
+      parameter name: :drug_name, in: :query, type: :string, required: true
+      parameter name: :Authorization, in: :header, type: :string, required: true, description: 'Bearer API key'
+
+      response '200', 'schedule retrieved' do
+        schema type: :object,
+               properties: {
+                 drug_name: { type: :string },
+                 interval_in_days: { type: :integer },
+                 starts_on: { type: :string, format: 'date' },
+                 injections: {
+                   type: :array,
+                   items: {
+                     type: :object,
+                     properties: {
+                       id: { type: :integer },
+                       drug_name: { type: :string },
+                       dose: { type: :number },
+                       lot_number: { type: :string },
+                       injected_at: { type: :string, format: 'date-time' }
+                     },
+                     required: ['id', 'drug_name', 'dose', 'lot_number', 'injected_at']
+                   }
+                 }
+               },
+               required: ['drug_name', 'interval_in_days', 'starts_on', 'injections']
+
+        let(:patient) { Patient.create(name: 'Alice') }
+        let(:patient_id) { patient.id }
+        let(:Authorization) { "Bearer #{patient.api_key}" }
+        let(:drug_name) { patient.schedules.first.drug_name }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/injections_spec.rb
+++ b/spec/integration/injections_spec.rb
@@ -1,0 +1,56 @@
+require 'swagger_helper'
+
+RSpec.describe 'Injections API', type: :request do
+  path '/api/v1/patients/{patient_id}/injections' do
+    post 'Create an injection' do
+      tags 'Injections'
+      consumes 'application/json'
+      produces 'application/json'
+
+      parameter name: :patient_id, in: :path, type: :string
+      parameter name: :Authorization, in: :header, type: :string, required: true, description: 'Bearer API key'
+      parameter name: :injection, in: :body, schema: {
+        type: :object,
+        properties: {
+          injection: {
+            type: :object,
+            properties: {
+              drug_name: { type: :string },
+              dose: { type: :number },
+              lot_number: { type: :string }
+            },
+            required: ['drug_name', 'dose', 'lot_number']
+          }
+        }
+      }
+
+      response '201', 'injection created' do
+        schema type: :object,
+               properties: {
+                 id: { type: :integer },
+                 drug_name: { type: :string },
+                 dose: { type: :number },
+                 lot_number: { type: :string },
+                 injected_at: { type: :string, format: 'date-time' }
+               },
+               required: ['id', 'drug_name', 'dose', 'lot_number', 'injected_at']
+
+        let(:patient) { Patient.create(name: 'Alice') }
+        let(:patient_id) { patient.id }
+        let(:Authorization) { "Bearer #{patient.api_key}" }
+        let(:injection) { { injection: { drug_name: patient.schedules.first.drug_name, dose: 10, lot_number: '#12345' } } }
+
+        run_test!
+      end
+
+      response '422', 'invalid request' do
+        let(:patient) { Patient.create(name: 'Bob') }
+        let(:patient_id) { patient.id }
+        let(:Authorization) { "Bearer #{patient.api_key}" }
+        let(:injection) { { injection: { drug_name: patient.schedules.first.drug_name, dose: -1, lot_number: '#12345' } } }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/integration/patients_spec.rb
+++ b/spec/integration/patients_spec.rb
@@ -39,4 +39,32 @@ RSpec.describe 'Patients API', type: :request do
       end
     end
   end
+
+  path '/api/v1/patients/{id}' do
+    get 'Show a patient' do
+      tags 'Patients'
+      produces 'application/json'
+      parameter name: :id, in: :path, type: :string, description: 'Patient ID'
+
+      response '200', 'patient found' do
+        schema type: :object,
+               properties: {
+                 id: { type: :integer },
+                 name: { type: :string },
+                 api_key: { type: :string }
+               },
+               required: ['id', 'name', 'api_key']
+
+        let(:id) { Patient.create(name: 'Alice').id }
+
+        run_test!
+      end
+
+      response '404', 'patient not found' do
+        let(:id) { 'invalid' }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/integration/ping_spec.rb
+++ b/spec/integration/ping_spec.rb
@@ -1,0 +1,20 @@
+require 'swagger_helper'
+
+RSpec.describe 'Service ping', type: :request do
+  path '/ping' do
+    get 'Ping the service' do
+      tags 'Health'
+      produces 'application/json'
+
+      response '200', 'service alive' do
+        schema type: :object,
+               properties: {
+                 status: { type: :string }
+               },
+               required: ['status']
+
+        run_test!
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- document all endpoints for OpenAPI generation

## Testing
- `bundle exec rspec spec/integration/ping_spec.rb` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882a761662083238574f1eea94e09ef